### PR TITLE
fix typo: add forgotten backticks / $()

### DIFF
--- a/etc/linuxmuster-client/post-mount.d/002-nautilus
+++ b/etc/linuxmuster-client/post-mount.d/002-nautilus
@@ -11,5 +11,5 @@ if [ $USER != $VOLUME ]; then
 fi
 
 # Action starts here
-linktargets=read_simple_config ${CONFDIR}/nautilus-bookmarks.conf
+linktargets=$(read_simple_config ${CONFDIR}/nautilus-bookmarks.conf)
 $LOGGING && msg2log post-mount $linktargets


### PR DESCRIPTION
pam_mount(mount.c:73): /etc/linuxmuster-client/post-mount.d/002-nautilus: line 14: /etc/linuxmuster-client/profile/nautilus-bookmarks.conf: Permission denied

das read_simple_config scheint ja eher ein Befehl zu sein, der ausgeführt werden soll mit Parameter - daher nehme ich mal stark an, dass da Backticks drum sollen
