### PR TITLE
Made adding of own scripts easier.

### DIFF
--- a/etc/linuxmuster-client/pre-mount.d/010-profilecopy
+++ b/etc/linuxmuster-client/pre-mount.d/010-profilecopy
@@ -1,0 +1,24 @@
+# this file is sourced from /usr/sbin/linuxmuster-pam-mount
+
+# source config file
+. /etc/linuxmuster-client/profile/profile.conf || exit 1
+# source profile functions
+. /var/lib/linuxmuster-client-profile/functions.inc || exit 1
+
+# log some info
+$LOGGING && msg2log pre-mount "Entering 010-profilecopy $1 $2"
+
+$LOGGING && msg2log pre-mount "Environment settings are: USER=$USER VOLUME=$VOLUME MNPT=$MNTPT OPTIONS=$OPTIONS SERVER=$SERVER NUMUID=$NUMUID NUMPRIGID=$NUMPRIGID FULLNAME=$FULLNAME HOMEDIR=$HOMEDIR LOGINSHELL=$LOGINSHELL"
+
+# this script gets executed only once, before the users home from the
+# server gets mounted. in this case $USER and $VOLUME are the same
+if [ $USER != $VOLUME ]; then
+    return 0
+fi
+
+# log success
+$LOGGING && msg2log pre-mount "We are mounting users home, copy default profile"
+
+rsync -r $RSYNC_OPTIONS /home/$PROFILE_USER/ $HOMEDIR/
+
+mkdir -p $MNTPT

--- a/etc/linuxmuster-client/pre-mount.d/020-chmod-user
+++ b/etc/linuxmuster-client/pre-mount.d/020-chmod-user
@@ -6,7 +6,7 @@
 . /var/lib/linuxmuster-client-profile/functions.inc || exit 1
 
 # log some info
-$LOGGING && msg2log pre-mount "Entering 001-profilecopy $1 $2"
+$LOGGING && msg2log pre-mount "Entering 020-chmod-user $1 $2"
 
 $LOGGING && msg2log pre-mount "Environment settings are: USER=$USER VOLUME=$VOLUME MNPT=$MNTPT OPTIONS=$OPTIONS SERVER=$SERVER NUMUID=$NUMUID NUMPRIGID=$NUMPRIGID FULLNAME=$FULLNAME HOMEDIR=$HOMEDIR LOGINSHELL=$LOGINSHELL"
 
@@ -16,10 +16,4 @@ if [ $USER != $VOLUME ]; then
     return 0
 fi
 
-# log success
-$LOGGING && msg2log pre-mount "We are mounting users home, copy default profile"
-
-rsync -r $RSYNC_OPTIONS /home/$PROFILE_USER/ $HOMEDIR/
-
-mkdir -p $MNTPT
 chown -R $USER $HOMEDIR


### PR DESCRIPTION
- Leave some space in the numbering of the scripts to allow custom scripts to be executed at a certain point in the execution order.
- Split profilecopy into two scripts:
  - rsync part
  - chmod part
