### PR TITLE
Set restrictive permissions on $HOMEDIR.

### DIFF
--- a/etc/linuxmuster-client/pre-mount.d/020-chown-user
+++ b/etc/linuxmuster-client/pre-mount.d/020-chown-user
@@ -6,7 +6,7 @@
 . /var/lib/linuxmuster-client-profile/functions.inc || exit 1
 
 # log some info
-$LOGGING && msg2log pre-mount "Entering 020-chmod-user $1 $2"
+$LOGGING && msg2log pre-mount "Entering 020-chown-user $1 $2"
 
 # this script gets executed only once, before the users home from the
 # server gets mounted. in this case $USER and $VOLUME are the same
@@ -14,5 +14,4 @@ if [ $USER != $VOLUME ]; then
     return 0
 fi
 
-# Set restrictive permissions on $HOMEDIR.
-chmod 750 $HOMEDIR
+chown -R $USER $HOMEDIR

--- a/etc/linuxmuster-client/profile/nautilus-bookmarks.conf
+++ b/etc/linuxmuster-client/profile/nautilus-bookmarks.conf
@@ -1,6 +1,6 @@
 # Absolute paths starting with / will be taken as
   # absolute paths
-# Paths not starting with a slash will be intrpreted
+# Paths not starting with a slash will be interpreted
 # relatively to the homedir of the current user logging in
 #Beispiele
 #Home_auf_Server/Eigene\ Dateien


### PR DESCRIPTION
The default permissions (at least on Linux Mint 17 Qiana) are 755 which
are a bit permissive.

Anyone else who noticed that the permissions of users are a bit to wide (at least for my taste)?

With this patch, teachers still have access to everything but students only have access to there own home directory because each student home directory is in group teachers.