### PR TITLE
Jollyzsher checkemptyhome differentserver

### DIFF
--- a/etc/linuxmuster-client/post-mount.d/002-nautilus
+++ b/etc/linuxmuster-client/post-mount.d/002-nautilus
@@ -4,10 +4,15 @@
 $LOGGING && msg2log post-mount "Entering 002-nautilus $1 $2"
 $LOGGING && msg2log post-mount "Environment settings are: USER=$USER VOLUME=$VOLUME MNPT=$MNTPT OPTIONS=$OPTIONS SERVER=$SERVER NUMUID=$NUMUID NUMPRIGID=$NUMPRIGID FULLNAME=$FULLNAME HOMEDIR=$HOMEDIR LOGINSHELL=$LOGINSHELL"
 
-# this script gets executed only once, after the users home from the
-# server gets mounted. in this case $USER and $VOLUME are the same
-if [ $USER != $VOLUME ]; then
-    return 0
+# this script should only get executed once, before the users home from the
+# server gets mounted. In this case $USER and $VOLUME are the same.
+# $USER and $VOLUME can also be the same, when mounting $VOLUME from a different server,
+# thus return if $USER and $VOLUME are different or if the serverip is different from the serverip of the main server
+requestserverip=$(gethostip $SERVER | awk '{print $2}')
+lmlserverip=$(grep "^uri\ ldap://" /etc/ldap.conf | head -n 1 | sed "s@^uri\ ldap://@@;s@/.*@@")
+if [ $USER != $VOLUME -o $lmlserverip != $requestserverip ]; then
+   msg2log pre-mount "LML: $lmlserverip, Request: $requestserverip"
+   return 0
 fi
 
 # Action starts here

--- a/etc/linuxmuster-client/post-mount.d/004-profile-links
+++ b/etc/linuxmuster-client/post-mount.d/004-profile-links
@@ -53,12 +53,15 @@ SERVEREINSTELLUNGEN=`echo $HOMEFOLDERNAME/$HOMEPREFERENCEFOLDERNAME`
 # daher auskommentiert
 #HOMEDIR="`pwd`"
  
-# Dieses Script soll nur einmal ausgeführt werden.
-# Nur nachdem das Serverhome des Benutzers gemountet wurde,
-# sind $USER und $VOLUME identisch, in allen anderen Fällen
-# bricht das Script ab.
-if [ $USER != $VOLUME ]; then
-    return 0
+# this script should only get executed once, before the users home from the
+# server gets mounted. In this case $USER and $VOLUME are the same.
+# $USER and $VOLUME can also be the same, when mounting $VOLUME from a different server,
+# thus return if $USER and $VOLUME are different or if the serverip is different from the serverip of the main server
+requestserverip=$(gethostip $SERVER | awk '{print $2}')
+lmlserverip=$(grep "^uri\ ldap://" /etc/ldap.conf | head -n 1 | sed "s@^uri\ ldap://@@;s@/.*@@")
+if [ $USER != $VOLUME -o $lmlserverip != $requestserverip ]; then
+   msg2log pre-mount "LML: $lmlserverip, Request: $requestserverip"
+   return 0
 fi
 
 # Ist das Verzeichnis $SERVEREINSTELLUNGEN nicht vorhanden, 

--- a/etc/linuxmuster-client/pre-mount.d/010-profilecopy
+++ b/etc/linuxmuster-client/pre-mount.d/010-profilecopy
@@ -10,9 +10,22 @@ $LOGGING && msg2log pre-mount "Entering 010-profilecopy $1 $2"
 
 $LOGGING && msg2log pre-mount "Environment settings are: USER=$USER VOLUME=$VOLUME MNPT=$MNTPT OPTIONS=$OPTIONS SERVER=$SERVER NUMUID=$NUMUID NUMPRIGID=$NUMPRIGID FULLNAME=$FULLNAME HOMEDIR=$HOMEDIR LOGINSHELL=$LOGINSHELL"
 
-# this script gets executed only once, before the users home from the
-# server gets mounted. in this case $USER and $VOLUME are the same
-if [ $USER != $VOLUME ]; then
+# this script should only get executed once, before the users home from the
+# server gets mounted. In this case $USER and $VOLUME are the same.
+# $USER and $VOLUME can also be the same, when mounting $VOLUME from a different server,
+# thus return if $USER and $VOLUME are different or if the serverip is different from the serverip of the main server
+requestserverip=$(gethostip $SERVER | awk '{print $2}')
+lmlserverip=$(grep "^uri\ ldap://" /etc/ldap.conf | head -n 1 | sed "s@^uri\ ldap://@@;s@/.*@@")
+if [ $USER != $VOLUME -o $lmlserverip != $requestserverip ]; then
+   msg2log pre-mount "LML: $lmlserverip, Request: $requestserverip"
+   return 0
+fi
+
+# Additional check, if the Home_auf_Server Directory is not empty and return
+# If it was not empty, it would be bad to sync the profile
+. /etc/linuxmuster-client/linuxmuster-client.conf || exit 1
+if [ "$(ls -A $HOMEDIR/$HOMEFOLDERNAME)" ]; then
+    msg2log pre-mount "$HOMEFOLDERNAME is not empty, not syncing."
     return 0
 fi
 

--- a/etc/linuxmuster-client/pre-mount.d/020-chmod-user
+++ b/etc/linuxmuster-client/pre-mount.d/020-chmod-user
@@ -10,9 +10,22 @@ $LOGGING && msg2log pre-mount "Entering 020-chmod-user $1 $2"
 
 $LOGGING && msg2log pre-mount "Environment settings are: USER=$USER VOLUME=$VOLUME MNPT=$MNTPT OPTIONS=$OPTIONS SERVER=$SERVER NUMUID=$NUMUID NUMPRIGID=$NUMPRIGID FULLNAME=$FULLNAME HOMEDIR=$HOMEDIR LOGINSHELL=$LOGINSHELL"
 
-# this script gets executed only once, before the users home from the
-# server gets mounted. in this case $USER and $VOLUME are the same
-if [ $USER != $VOLUME ]; then
+# this script should only get executed once, before the users home from the
+# server gets mounted. In this case $USER and $VOLUME are the same.
+# $USER and $VOLUME can also be the same, when mounting $VOLUME from a different server,
+# thus return if $USER and $VOLUME are different or if the serverip is different from the serverip of the main server
+requestserverip=$(gethostip $SERVER | awk '{print $2}')
+lmlserverip=$(grep "^uri\ ldap://" /etc/ldap.conf | head -n 1 | sed "s@^uri\ ldap://@@;s@/.*@@")
+if [ $USER != $VOLUME -o $lmlserverip != $requestserverip ]; then
+   msg2log pre-mount "LML: $lmlserverip, Request: $requestserverip"
+   return 0
+fi
+
+# Additional check, if the Home_auf_Server Directory is not empty and return
+# If it was not empty, it would be bad to sync the profile
+. /etc/linuxmuster-client/linuxmuster-client.conf || exit 1
+if [ "$(ls -A $HOMEDIR/$HOMEFOLDERNAME)" ]; then
+    msg2log pre-mount "$HOMEFOLDERNAME is not empty, not syncing."
     return 0
 fi
 


### PR DESCRIPTION
Problem: 
Wenn man als SERVER einen anderen SAMBA-Server verwenden will (z.B. NAS im Lehrernetz), dann macht es sinn, wenn VOLUME und USER gleich sind, allerdings die Serverip != LMLserverip
Betrifft auch Dateien in linuxmuster-client-shares

außerdem:
bei pre-mount skripten sollte man nochmals checken ob "HOME_auf_Server" auch wirklich leer ist, sonst überschreibt man mit dem rsync das komplette home-verzeichnis.
